### PR TITLE
Lightning updates

### DIFF
--- a/src/ompl/geometric/planners/experience/src/LightningRetrieveRepair.cpp
+++ b/src/ompl/geometric/planners/experience/src/LightningRetrieveRepair.cpp
@@ -409,7 +409,7 @@ bool ompl::geometric::LightningRetrieveRepair::repairPath(ompl::geometric::PathG
 
             if (!replan(fromState, toState, newPathSegment, ptc))
             {
-                OMPL_WARN("Unable to repair path between state %d and %d", fromID, toID);
+                OMPL_INFORM("Unable to repair path between state %d and %d", fromID, toID);
                 return false;
             }
 
@@ -482,7 +482,7 @@ bool ompl::geometric::LightningRetrieveRepair::replan(const ompl::base::State *s
     double planTime = time::seconds(time::now() - startTime);
     if (!lastStatus)
     {
-        OMPL_WARN("Replan Solve: No replan solution between disconnected states found after %f seconds", planTime);
+        OMPL_INFORM("Replan Solve: No replan solution between disconnected states found after %f seconds", planTime);
         return false;
     }
 

--- a/src/ompl/tools/experience/ExperienceSetup.h
+++ b/src/ompl/tools/experience/ExperienceSetup.h
@@ -213,6 +213,14 @@ namespace ompl
                 return stats_;
             }
 
+            /**
+             * \brief Allow accumlated experiences to be processed
+             */
+            virtual bool doPostProcessing()
+            {
+                return true;
+            }
+
         protected:
 
             /// Flag indicating whether recalled plans should be used to find solutions. Enabled by default.

--- a/src/ompl/tools/lightning/src/Lightning.cpp
+++ b/src/ompl/tools/lightning/src/Lightning.cpp
@@ -233,7 +233,7 @@ ompl::base::PlannerStatus ompl::tools::Lightning::solve(const base::PlannerTermi
             stats_.numSolutionsApproximate_++;
 
             // not sure what to do here, use case not tested
-            OMPL_WARN("NOT saving to database because the solution is APPROXIMATE");
+            OMPL_INFORM("NOT saving to database because the solution is APPROXIMATE");
         }
         // Use dynamic time warping to see if the repaired path is too similar to the original
         else if (getSolutionPlannerName() == rrPlanner_->getName())
@@ -272,7 +272,7 @@ ompl::base::PlannerStatus ompl::tools::Lightning::solve(const base::PlannerTermi
 
                 if (score < 4)
                 {
-                    OMPL_WARN("NOT saving to database because best solution was from database and is too similar (score %f)", score);
+                    OMPL_INFORM("NOT saving to database because best solution was from database and is too similar (score %f)", score);
 
                     // Logging
                     log.insertion_failed = true;


### PR DESCRIPTION
Reduced various warnings to just `INFORM` because they are intended functionality

Added new virtual function `doPostProcessing()` to `ExperienceSetup` that allows an experience planner (Thunder) to process a new trajectory into its database in an asynchronous manner. 

In preparation for Thunder PR
